### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sounds of Street View Framework
 
-###A JavaScript library to add sound to a Google Street View experience.
+### A JavaScript library to add sound to a Google Street View experience.
 
 Watch the promotional video for an explanation and overview of what can be achieved 
 with the Sounds of Street View Framework.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
